### PR TITLE
Add link to python implementation

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -844,6 +844,9 @@ Implementations</h2>
       <a href="https://github.com/mathiasbynens/wtf-8">wtf-8.js</a>
       implements this specification in JavaScript.
     <li>
+      <a href="https://gist.github.com/kouk/d4e1faababf14b09b27f">wtf8.py</a>
+      implements this specification in Python.
+    <li>
       <a href="https://github.com/SimonSapin/rust-wtf8">rust-wtf8</a>
       implements this specification in <a href="http://www.rust-lang.org/">Rust</a>.
     <li>


### PR DESCRIPTION
Hi,

I made a Python implementation of WTF-8, albeit a quick and dirty one. It supports both Python 3 and Python 2.7 (perhaps even earlier versions). You can find it here:

https://gist.github.com/kouk/d4e1faababf14b09b27f

I would appreciate any feedback, or contributions. Known issues:
1. no serious testing (works for me),
2. no packaging, just add and import from your own source,
3. depends on [six](http://pythonhosted.org/six/)
